### PR TITLE
alfred horizontal add buttons

### DIFF
--- a/Alfred.css
+++ b/Alfred.css
@@ -23,14 +23,18 @@ body:not(.uk-offcanvas-container) .alfred:hover {
 }
 .alfred .icons,
 .alfred .add-top,
-.alfred .add-bottom {
+.alfred .add-bottom,
+.alfred .add-left,
+.alfred .add-right {
   display: none;
   position: absolute;
   pointer-events: none;
 }
 .alfred .icons img,
 .alfred .add-top img,
-.alfred .add-bottom img {
+.alfred .add-bottom img,
+.alfred .add-left img,
+.alfred .add-right img {
   display: inline-block;
   width: 15px !important;
   height: 30px !important;
@@ -40,7 +44,9 @@ body:not(.uk-offcanvas-container) .alfred:hover {
 }
 .alfred .icons a.icon,
 .alfred .add-top a.icon,
-.alfred .add-bottom a.icon {
+.alfred .add-bottom a.icon,
+.alfred .add-left a.icon,
+.alfred .add-right a.icon {
   pointer-events: all;
   border-radius: 0;
   background-color: white;
@@ -65,6 +71,18 @@ body:not(.uk-offcanvas-container) .alfred:hover {
   right: 0;
   text-align: center;
 }
+.alfred .add-left {
+  top: 50%;
+  transform: translateY(-50%);
+  left: 0;
+  text-align: center;
+}
+.alfred .add-right {
+  top: 50%;
+  transform: translateY(-50%);
+  right: 0;
+  text-align: center;
+}
 .alfred .icons {
   top: -1px;
   right: 0;
@@ -83,5 +101,11 @@ body:not(.uk-offcanvas-container) .alfred:hover {
   display: inline-block;
 }
 .alfred:hover > .add-bottom {
+  display: inline-block;
+}
+.alfred:hover > .add-left {
+  display: inline-block;
+}
+.alfred:hover > .add-right {
   display: inline-block;
 }

--- a/Alfred.js
+++ b/Alfred.js
@@ -41,8 +41,10 @@
       let config = JSON.parse($(el).attr('alfred'));
       this.addIcons(el, config.icons);
       if(config.widgetStyle) $(el).addClass('rmx-widget');
-      if(config.addTop) $(el).append(this.plus('top', config.addTop));
+      if(config.addTop ) $(el).append(this.plus('top', config.addTop));
       if(config.addBottom) $(el).append(this.plus('bottom', config.addBottom));
+      if(config.addLeft) $(el).append(this.plus('left', config.addLeft));
+      if(config.addRight) $(el).append(this.plus('right', config.addRight));
     } catch (error) {
       alert('invalid json in alfred - dont forget |noescape filter when working with latte files')
     }

--- a/Alfred.less
+++ b/Alfred.less
@@ -34,7 +34,7 @@ body:not(.uk-offcanvas-container) .alfred:hover {
 .alfred {
   position: relative;
 
-  .icons,.add-top,.add-bottom {
+  .icons,.add-top,.add-bottom,.add-left,.add-right {
     display: none;
     position: absolute;
     pointer-events: none;
@@ -66,6 +66,18 @@ body:not(.uk-offcanvas-container) .alfred:hover {
     right: 0;
     text-align: center;
   }
+  .add-left {
+    top: 50%;
+    transform: translateY(-50%);
+    left: 0;
+    text-align: center;
+  }
+  .add-right {
+    top: 50%;
+    transform: translateY(-50%);
+    right: 0;
+    text-align: center;
+  }
 
   // wrapping div with all icons
   .icons {
@@ -86,5 +98,7 @@ body:not(.uk-offcanvas-container) .alfred:hover {
     > .icons { display: inline-block; }
     > .add-top { display: inline-block; }
     > .add-bottom { display: inline-block; }
+    > .add-left { display: inline-block; }
+    > .add-right { display: inline-block; }
   }
 }

--- a/RockFrontend.module.php
+++ b/RockFrontend.module.php
@@ -282,6 +282,7 @@ class RockFrontend extends WireData implements Module, ConfigurableModule {
       'noBlock' => false, // prevent block icons if true
       'addTop' => null, // set to false to prevent icon
       'addBottom' => null, // set to false to prevent icon
+      'addHorizontal' => null, // shortcut for addLeft + addRight
       'move' => true,
       'isWidget' => $isWidget, // is block saved in rockmatrix_widgets?
       'widgetStyle' => $isWidget, // make it orange
@@ -301,12 +302,22 @@ class RockFrontend extends WireData implements Module, ConfigurableModule {
       // see explanation about widget above
       $widget = $page->_widget ?: $page;
 
-      if($opt->noBlock) {
-        if($opt->addTop !== true) $opt->addTop = false;
-        if($opt->addBottom !== true) $opt->addBottom = false;
+      if ($opt->noBlock) {
+        if ($opt->addTop !== true) $opt->addTop = false;
+        if ($opt->addBottom !== true) $opt->addBottom = false;
+        if ($opt->addHorizontal !== true) {
+          $opt->addLeft = false;
+          $opt->addRight = false;
       }
-      if($opt->addTop !== false) $opt->addTop = $widget->rmxUrl("/add/?block=$widget&above=1");
-      if($opt->addBottom !== false) $opt->addBottom = $widget->rmxUrl("/add/?block=$widget");
+      }
+      if ($opt->addTop !== false) $opt->addTop = $widget->rmxUrl("/add/?block=$widget&above=1");
+      if ($opt->addBottom !== false) $opt->addBottom = $widget->rmxUrl("/add/?block=$widget");
+      if ($opt->addHorizontal === true) {
+        $opt->addTop = false;
+        $opt->addBottom = false;
+        $opt->addLeft = $widget->rmxUrl("/add/?block=$widget&above=1");
+        $opt->addRight = $widget->rmxUrl("/add/?block=$widget");
+      }
 
       $blockid = " data-rmxblock=$widget ";
     }
@@ -315,6 +326,8 @@ class RockFrontend extends WireData implements Module, ConfigurableModule {
       'icons' => $icons,
       'addTop' => $opt->addTop,
       'addBottom' => $opt->addBottom,
+      'addLeft' => $opt->addLeft,
+      'addRight' => $opt->addRight,
       'widgetStyle' => $opt->widgetStyle,
     ]);
 


### PR DESCRIPTION
added Alfred config option "addHorizontal" to make adding blocks before and after more intuitive in scenarios where the blocks are aligned horizontally e.g. in sliders.
When calling alfred with `<?= alfred($block, ['addHorizontal' => true]) ?>`, the add before and add after buttons are aligned to the left and right respectively.