### PR TITLE
fix: WireFileTools error if templates/less doesn't exist

### DIFF
--- a/RockFrontend.module.php
+++ b/RockFrontend.module.php
@@ -604,7 +604,10 @@ class RockFrontend extends WireData implements Module, ConfigurableModule
     $file = $this->lessFilePath();
     if (is_file($file)) return;
     $less = $this->wire->pages->get(1)->getFormatted(self::field_less);
-    $this->wire->files->filePutContents($file, $less);
+    // create only if directory templates/less exists
+    if (is_dir($this->wire->config->paths->templates . "less")) {
+      $this->wire->files->filePutContents($file, $less);
+    }
   }
 
   /**


### PR DESCRIPTION
Hi,
I do not work with less and get a WireFileTools error on every reload (backend and frontend) because the rf-custom.less cannot be copied to templates/less if there is no less dir.
Added a fix for that 