### PR TITLE
feat: detect htmx requests

### DIFF
--- a/RockFrontend.module.php
+++ b/RockFrontend.module.php
@@ -440,7 +440,8 @@ class RockFrontend extends WireData implements Module, ConfigurableModule
           // make htmx endpoints only available via ajax
           // superusers are allowed to access them directly (for debugging)
           $sudo = $this->wire->user->isSuperuser();
-          $ajax = $this->wire->config->ajax;
+          $isHtmx = isset($_SERVER['HTTP_HX_REQUEST']) && $_SERVER['HTTP_HX_REQUEST'];
+          $ajax = $this->wire->config->ajax || $isHtmx;
 
           if (!$ajax and $sudo) return $this->ajaxDebug($endpoint);
           else return $this->ajaxPublic($endpoint);


### PR DESCRIPTION
Hi, this PR checks for htmx specific request header HX-Request to set $ajax. No need to set the X-Requested-With: XMLHttpRequest header that PW uses to identify AJAX requests when using htmx.
See: https://htmx.org/docs/#request-headers

Note: headers can only be detected if they are correctly passed on to PHP-FPM by the server. If they are not there, server configuration (Apache or nginx) must be adjusted.
   