### PR TITLE
fix: error when $refs null due to network problems

### DIFF
--- a/RockFrontend.module.php
+++ b/RockFrontend.module.php
@@ -1351,6 +1351,8 @@ class RockFrontend extends WireData implements Module, ConfigurableModule
 
   /**
    * Get uikit versions from github
+   * @param bool $noCache load from cache?
+   * @return array
    */
   public function getUikitVersions($noCache = false)
   {
@@ -1358,20 +1360,22 @@ class RockFrontend extends WireData implements Module, ConfigurableModule
     if ($noCache) $expire = WireCache::expireNow;
     $versions = $this->wire->cache->get(self::cache, $expire, function () {
       $http = new WireHttp();
-      $json = $http->get('https://api.github.com/repos/uikit/uikit/git/refs/tags');
-      $refs = json_decode($json);
-      $versions = [];
-      foreach ($refs as $ref) {
-        $version = str_replace("refs/tags/", "", $ref->ref);
-        $v = $version;
-        if (strpos($version, "v.") === 0) continue;
-        if (strpos($version, "v") !== 0) continue;
-        $versions[$v] = $version;
+      $refs = $http->getJSON('https://api.github.com/repos/uikit/uikit/git/refs/tags', $assoc = false);
+      if ($refs) {
+        $versions = [];
+        foreach ($refs as $ref) {
+          $version = str_replace("refs/tags/", "", $ref->ref);
+          $v = $version;
+          if (strpos($version, "v.") === 0) continue;
+          if (strpos($version, "v") !== 0) continue;
+          $versions[$v] = $version;
+        }
+        uasort($versions, "version_compare");
+        return array_reverse($versions);
       }
-      uasort($versions, "version_compare");
-      return array_reverse($versions);
+      return [];
     });
-    if ($versions) return $versions;
+    if (!empty($versions)) return $versions;
     if (!$noCache) return $this->getUikitVersions(true);
     return [];
   }


### PR DESCRIPTION
I discovered this error while being connected to www through VPN. fsockopen couldn't resolve DNS. So $refs where null and could not be foreached.
Solved this with check for $refs.

Also use getJSON() method and unify return val to array. And added docblock @param and @return


 