### PR TITLE
fix: avoid TypeError $ is not defined on slow connections

### DIFF
--- a/RockFrontend.module.php
+++ b/RockFrontend.module.php
@@ -324,7 +324,7 @@ class RockFrontend extends WireData implements Module, ConfigurableModule
     if (!$skipAssets) {
       $this->js("rootUrl", $this->wire->config->urls->root);
       $this->js("defaultVspaceScale", number_format(self::defaultVspaceScale, 2, ".", ""));
-      $this->scripts('rockfrontend')->add(__DIR__ . "/Alfred.min.js");
+      $this->scripts('rockfrontend')->add(__DIR__ . "/Alfred.min.js", "defer");
       $this->addAlfredStyles();
     }
 


### PR DESCRIPTION
Getting this error on slow connections:
```
Alfred.min.js?m=1724311768:5 Uncaught (in promise) TypeError: $ is not a function
    at Alfred.initItem (Alfred.min.js?m=1724311768:5:179)
```
Because jQueryCore.js is loaded in head and Alfred.min.js in body.
defer attribute avoids that.

The logic in Alfred.js at https://github.com/baumrock/RockFrontend/blob/59e7856a151aba7287cdcdedf9534a19de2badf1/Alfred.js#L144 only accounts for 10 seconds
That could be improved also. But defer is the simplest fix. 